### PR TITLE
Uses Debian Stretch instead of jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amancevice/pandas:0.20.2-python3
+FROM python:3.6-stretch
 
 # Superset version
 ARG SUPERSET_VERSION=0.19.1


### PR DESCRIPTION
## Proposal

Uses Debian 9 instead of Debian 8 to pick up latest software depended by superset drivers. E.g., OpenJDK 8.

I found the docker image `amancevice/pandas:0.20.2-python3` is built from `python:3.6` which is based on Jessie, is it ok that it uses Stretch in this docker image?