### PR TITLE
Add Celery worker in examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN useradd -U -m superset && \
         redis==2.10.5 \
         sqlalchemy-redshift==0.5.0 \
         sqlalchemy-clickhouse==0.1.1.post3 \
+        Werkzeug==0.12.1 \
         superset==${SUPERSET_VERSION}
 
 # Configure Filesystem

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,13 @@
 # Superset Examples
 
-Example configurations for MySQL, PostgreSQL, and SQLite are provided, along with a simple demo script for starting them.
+Example configurations for MySQL, PostgreSQL, SQLite, and Celery are provided, along with a simple demo script for starting them.
 
 Each demo provides a `superset_config.py` and a `docker-compose.yml`. Use these as guides for laying down your own instances.
 
-Start a demo of Superset using the `demo.sh` script. The script takes a single argument that determines the back end for Superset: `sqlite`, `mysql`, or `postgres`.
+Start a demo of Superset using the `demo.sh` script. The script takes a single argument that determines the back end for Superset: `sqlite`, `mysql`, `postgres`, or `celery`.
 
 ```bash
-bash demo.sh mysql|postgres|sqlite
+bash demo.sh mysql|postgres|sqlite|celery
 ```
 
 You will be prompted to set up an admin user.
@@ -33,7 +33,7 @@ docker-compose up -d redis mysql
 docker-compose up -d superset
 # Wait for Superset to come up fully...
 
-# Inititalize Superset DB
+# Initialize Superset DB
 docker-compose exec superset superset-demo
 # or `docker-compose exec superset superset-init` if no demo data needed
 
@@ -56,7 +56,7 @@ docker-compose up -d redis postgres
 docker-compose up -d superset
 # Wait for Superset to come up fully...
 
-# Inititalize demo
+# Initialize demo
 docker-compose exec superset superset-demo
 # or `docker-compose exec superset superset-init` if no demo data needed
 
@@ -82,7 +82,33 @@ touch superset.db
 docker-compose up -d superset
 # Wait for Superset to come up fully...
 
-# Inititalize demo
+# Initialize demo
+docker-compose exec superset superset-demo
+# or `docker-compose exec superset superset-init` if no demo data needed
+
+# Play around in demo...
+
+# Bring everything down
+docker-compose down -v
+```
+
+## Celery
+
+```bash
+cd celery
+
+# Start Redis & PostgreSQL services
+docker-compose up -d redis postgres
+# Wait for services to come up fully...
+
+# Start Superset
+docker-compose up -d superset
+# Wait for Superset to come up fully...
+
+# Start Celery worker
+docker-compose up -d worker
+
+# Initialize demo
 docker-compose exec superset superset-demo
 # or `docker-compose exec superset superset-init` if no demo data needed
 

--- a/examples/celery/docker-compose.yml
+++ b/examples/celery/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3'
+services:
+  redis:
+    image: redis
+    restart: always
+    volumes:
+      - redis:/data
+  postgres:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: superset
+      POSTGRES_PASSWORD: superset
+      POSTGRES_USER: superset
+    volumes:
+      - postgres:/var/lib/postgresql/data
+  superset:
+    image: amancevice/superset
+    restart: always
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      MAPBOX_API_KEY: ${MAPBOX_API_KEY}
+    ports:
+      - "8088:8088"
+    volumes:
+      - ./superset:/etc/superset
+  worker:
+    image: amancevice/superset
+    restart: always
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      MAPBOX_API_KEY: ${MAPBOX_API_KEY}
+    volumes:
+      - ./superset:/etc/superset
+    command: worker
+volumes:
+  postgres:
+    external: false
+  redis:
+    external: false

--- a/examples/celery/superset/superset_config.py
+++ b/examples/celery/superset/superset_config.py
@@ -1,0 +1,33 @@
+import os
+
+from werkzeug.contrib.cache import RedisCache
+
+
+MAPBOX_API_KEY = os.getenv('MAPBOX_API_KEY', '')
+CACHE_CONFIG = {
+    'CACHE_TYPE': 'redis',
+    'CACHE_DEFAULT_TIMEOUT': 300,
+    'CACHE_KEY_PREFIX': 'superset_',
+    'CACHE_REDIS_HOST': 'redis',
+    'CACHE_REDIS_PORT': 6379,
+    'CACHE_REDIS_DB': 1,
+    'CACHE_REDIS_URL': 'redis://redis:6379/1'}
+SQLALCHEMY_DATABASE_URI = \
+    'postgresql+psycopg2://superset:superset@postgres:5432/superset'
+SQLALCHEMY_TRACK_MODIFICATIONS = True
+SECRET_KEY = 'thisISaSECRET_1234'
+
+
+class CeleryConfig(object):
+    BROKER_URL = 'redis://redis:6379/0'
+    CELERY_IMPORTS = ('superset.sql_lab', )
+    CELERY_RESULT_BACKEND = 'redis://redis:6379/0'
+    CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
+
+
+CELERY_CONFIG = CeleryConfig
+RESULTS_BACKEND = RedisCache(
+    host='redis',
+    port=6379,
+    key_prefix='superset_results'
+)

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -3,10 +3,10 @@
 set -e
 
 if [ -z $1 ]; then
-  echo "Usage: bash demo.sh mysql|postgres|sqlite"
+  echo "Usage: bash demo.sh mysql|postgres|sqlite|celery"
   exit 1
-elif [ "$1" != "mysql" ] && [ "$1" != "postgres" ] && [ "$1" != "sqlite" ]; then
-  echo "Usage: bash demo.sh mysql|postgres|sqlite"
+elif [ "$1" != "mysql" ] && [ "$1" != "postgres" ] && [ "$1" != "sqlite" ] && [ "$1" != "celery" ]; then
+  echo "Usage: bash demo.sh mysql|postgres|sqlite|celery"
   exit 1
 fi
 
@@ -17,9 +17,14 @@ if [ "$1" == "sqlite" ]; then
   echo "Starting redis service..."
   docker-compose up -d redis
   >| ./superset/superset.db
-else
+elif [ "$1" == "mysql" ] || [ "$1" == "postgres" ]; then
   echo "Starting redis & $1 services..."
   docker-compose up -d redis $1
+  echo "Sleeping for 30s"
+  sleep 30
+else
+  echo "Starting redis & postgres services..."
+  docker-compose up -d redis postgres
   echo "Sleeping for 30s"
   sleep 30
 fi
@@ -29,6 +34,11 @@ echo "Starting Superset..."
 docker-compose up -d superset
 echo "Sleeping for 30s"
 sleep 30
+
+if [ "$1" == "celery" ]; then
+  echo "Starting celery worker service..."
+  docker-compose up -d worker
+fi
 
 # Inititalize Demo
 docker-compose exec superset superset-demo

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -32,13 +32,12 @@ fi
 # Start Superset
 echo "Starting Superset..."
 docker-compose up -d superset
-echo "Sleeping for 30s"
-sleep 30
-
 if [ "$1" == "celery" ]; then
-  echo "Starting celery worker service..."
+  echo "Starting Superset worker..."
   docker-compose up -d worker
 fi
+echo "Sleeping for 30s"
+sleep 30
 
 # Inititalize Demo
 docker-compose exec superset superset-demo


### PR DESCRIPTION
I think it would be good for beginners to see how we can actually configure an asynchronous backend for long running queries described [here](http://superset.apache.org/installation.html#sql-lab).

Changes proposed in this pull request:
- Add `Werkzeug` package in `Dockerfile` to use `RedisCache`.
- Add Docker compose with a worker that uses Redis for results backend.
- Add instruction in `demo.sh` and `README.md`.