### PR TITLE
chore: Add libffi-dev to apt-get packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN useradd -U -m superset && \
         libpq-dev \
         libsasl2-dev \
         libssl-dev \
+        libffi-dev\
         openjdk-8-jdk \
         python3-dev \
         python3-pip && \


### PR DESCRIPTION
The python cryptography package needs libffi-dev on debian according to https://cryptography.io/en/latest/installation/. 
This worked on my own machine but failed on my jenkins slave running on ec2. Not sure what the underlying cause is but this fixes it. 