### PR TITLE
Fix for Impyla issue (https://github.com/cloudera/impyla/issues/268)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN useradd -U -m superset && \
         flask-oauth==0.12 \
         flask_oauthlib==0.9.3 \
         gevent==1.2.2 \
+        thrift_sasl==0.2.1 \
+        sasl \
         impyla==0.14.0 \
         mysqlclient==1.3.7 \
         psycopg2==2.6.1 \


### PR DESCRIPTION
 Latest versions of Superset images can't connect to Impala. This pull request solves the issue