### PR TITLE
Replaces pip sqlalchemy-clickhouse with JustOnce's Github version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN useradd -U -m superset && \
         pyldap==2.4.28 \
         pymssql==2.1.3 \
         redis==2.10.5 \
-        sqlalchemy-clickhouse==0.1.3.post0 \
+        https://github.com/JustOnce/sqlalchemy-clickhouse/archive/master.zip \
         sqlalchemy-redshift==0.5.0 \
         superset==${SUPERSET_VERSION} && \
     rm requirements.txt


### PR DESCRIPTION
Pip's version of sqlalchemy-clickhouse no longer works. [See this issue](https://github.com/cloudflare/sqlalchemy-clickhouse/issues/23)

The lack of compability yields errors when using aggregated functions as metrics and filters. See the second issue commented [here](https://github.com/apache/incubator-superset/issues/4677)