### PR TITLE
Set correct version of clickhouse-orm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN useradd -U -m superset && \
         flask_oauthlib==0.9.3 \
         gevent==1.2.2 \
         impyla==0.14.0 \
-        infi.clickhouse-orm==0.9.8 \
+        infi.clickhouse-orm==1.0.2 \
         mysqlclient==1.3.7 \
         psycopg2==2.6.1 \
         pyathena==1.2.5 \


### PR DESCRIPTION
Previous version of the clickhouse-orm does not work
When I tried to check connect to ClickHouse got error
```
RROR: {
    "error": "Connection failed!\n\nThe error message returned was:\n(infi.clickhouse-orm 0.9.8 (/usr/local/lib/python3.5/dist-packages), Requirement.parse('infi.clickhouse_orm>=1.0.0'))"
}
```