### PR TITLE
Fix click version conflict error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,12 @@ RUN useradd -U -m superset && \
     curl https://raw.githubusercontent.com/${SUPERSET_REPO}/${SUPERSET_VERSION}/requirements.txt -o requirements.txt && \
     pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir \
-        Werkzeug==0.12.1 \
-        flask-cors==3.0.3 \
+        Werkzeug==0.14.1 \
+        flask-cors==3.0.6 \
         flask-mail==0.9.1 \
         flask-oauth==0.12 \
         flask_oauthlib==0.9.3 \
+        click==6.7 \
         gevent==1.2.2 \
         impyla==0.14.0 \
         infi.clickhouse-orm==1.0.2 \


### PR DESCRIPTION
Current installation, somehow, install click version 7.0 causing `ContextualVersionConflict` error when run `superset-init` script which requires `click==6.7`.

To reproduce:
- Create docker container `docker run -d --name superset amancevice/superset:0.27.0`
- Run database initialization script `docker exec -it superset superset-init`

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 655, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 963, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 854, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (Click 7.0 (/usr/local/lib/python3.5/dist-packages), Requirement.parse('click==6.7'), {'Flask-AppBuilder'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/fabmanager", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3019, in <module>
    @_call_aside
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3003, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 657, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 670, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 849, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'click==6.7' distribution was not found and is required by Flask-AppBuilder
```