### PR TITLE
upgrade sqlalchemy-redshift to 0.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN useradd -U -m superset && \
         pymssql==2.1.3 \
         redis==2.10.5 \
         sqlalchemy-clickhouse==0.1.5.post0 \
-        sqlalchemy-redshift==0.5.0 \
+        sqlalchemy-redshift==0.7.1 \
         superset==${SUPERSET_VERSION} && \
     rm requirements.txt
 


### PR DESCRIPTION
Current version fails on SSL certificate validation