### PR TITLE
celery: Fix celery command in docker-compose.yml

### DIFF
--- a/examples/celery/docker-compose.yml
+++ b/examples/celery/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       MAPBOX_API_KEY: ${MAPBOX_API_KEY}
     volumes:
       - ./superset:/etc/superset
-    command: worker
+    command: celery worker
 volumes:
   postgres:
     external: false


### PR DESCRIPTION
* Change celery command in `docker-compose.yml` from `worker` to `celery worker`.