### PR TITLE
fix: Replace fbprophet for prophet in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ authlib==0.14.3
 clickhouse-sqlalchemy==0.1.6
 cx_oracle==7.3.0
 elasticsearch-dbapi==0.1.2
-fbprophet==0.7.1
 flask-cors==3.0.9
 flask-mail==0.9.1
 flask-oauth==0.12
@@ -12,6 +11,7 @@ impyla==0.14.0
 infi.clickhouse-orm==1.0.2
 mysqlclient==1.4.2
 pillow==8.3.2
+prophet==1.0.1
 psycopg2==2.8.6
 pyathena==1.5.1
 pybigquery==0.4.13


### PR DESCRIPTION
Looks like the `fbprophet` package (https://pypi.org/project/fbprophet/) was renamed to just `prophet` once upgraded to version 1.0 (https://pypi.org/project/prophet/).

Superset started requiring `prophet` instead of `fbprophet` (see PR: https://github.com/apache/superset/pull/14228) which is causing an error to pop up when installing this repo's image and attempting to use any of the `prophet` functionality:
![image](https://user-images.githubusercontent.com/18740659/139461937-4586d2cd-57f6-476a-b5dd-f09999872ce9.png)


Solution: replace `fbprophet` for `prophet` to match Superset's `setup.py`: https://github.com/apache/superset/blob/1.3/setup.py#L148