### PR TITLE
fix use correct servicename in docker-compose example readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ Here is a more detailed explanation of what the demo script is doing:
 cd mysql
 
 # Start Redis & MySQL services
-docker-compose up -d redis mysql
+docker-compose up -d redis db
 # Wait for services to come up fully...
 
 # Start Superset
@@ -49,7 +49,7 @@ docker-compose down -v
 cd postgres
 
 # Start Redis & PostgreSQL services
-docker-compose up -d redis postgres
+docker-compose up -d redis db
 # Wait for services to come up fully...
 
 # Start Superset
@@ -99,7 +99,7 @@ docker-compose down -v
 cd celery
 
 # Start Redis & PostgreSQL services
-docker-compose up -d redis postgres
+docker-compose up -d redis db
 # Wait for services to come up fully...
 
 # Start Superset


### PR DESCRIPTION
Services are called `db` and not by database name.